### PR TITLE
Change workflow from pull_request to push

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,9 +1,9 @@
-workflow "Pull request actions" {
+workflow "Push actions" {
   resolves = [
     "gimenete/eslint-action",
     "Block Autosquash Commits",
   ]
-  on = "pull_request"
+  on = "push"
 }
 
 action "gimenete/eslint-action" {

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ If any commit message in the pull request starts with `fixup!` or `squash!` the 
 ## Usage
 
 ```workflow
-workflow "Pull request" {
-  on = "pull_request"
+workflow "Push" {
+  on = "push"
   resolves = ["Block Autosquash Commits"]
 }
 


### PR DESCRIPTION
When this is set to `pull_request` the workflow runs not just when pushing code up, but also when editing labels, projects, etc. so it's better to use `push` for this.