### PR TITLE
Increase number of commits checked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Bumped `@actions/core` from 1.2.6 to 1.4.0
 - Bumped `@actions/github` from 4.0.0 to 5.0.0
+- Increased the number of commits checked from 30 to 250.
+  This is a limit of GitHub's API so if you're working on a really large PR your fixup commits might not be detected.
 
 ## Version 2.1.0
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A Github Action to prevent merging pull requests containing [autosquash](https:/
 
 If any commit message in the pull request starts with `fixup!` or `squash!` the check status will be set to `error`.
 
+>⚠️ GitHub's API only returns the first 250 commits of a PR so if you're working on a really large PR your fixup commits might not be detected.
+
 ## Usage
 
 ```yaml

--- a/pullRequestChecker.js
+++ b/pullRequestChecker.js
@@ -10,20 +10,23 @@ class PullRequestChecker {
     }
 
     async process() {
-        const commits = await this.client.rest.pulls.listCommits({
-            ...context.repo,
-            pull_number: context.issue.number,
-            per_page: 100,
-        });
+        const commits = await this.client.paginate(
+            "GET /repos/{owner}/{repo}/pulls/{pull_number}/commits",
+            {
+                ...context.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+            },
+        );
 
-        debug(`${commits.data.length} commit(s) in the pull request`);
+        debug(`${commits.length} commit(s) in the pull request`);
 
         let blockedCommits = 0;
-        for (const commit of commits.data) {
-            const isAutosquash = commit.commit.message.startsWith("fixup!") || commit.commit.message.startsWith("squash!");
+        for (const { commit: { message }, sha, url } of commits) {
+            const isAutosquash = message.startsWith("fixup!") || message.startsWith("squash!");
 
             if (isAutosquash) {
-                error(`Commit ${commit.sha} is an autosquash commit: ${commit.url}`);
+                error(`Commit ${sha} is an autosquash commit: ${url}`);
 
                 blockedCommits++;
             }

--- a/pullRequestChecker.js
+++ b/pullRequestChecker.js
@@ -13,6 +13,7 @@ class PullRequestChecker {
         const commits = await this.client.rest.pulls.listCommits({
             ...context.repo,
             pull_number: context.issue.number,
+            per_page: 100,
         });
 
         debug(`${commits.data.length} commit(s) in the pull request`);


### PR DESCRIPTION
The original check was only getting the first 30 commits, this increases it to 100 per page and paginates the results to get all of them. The endpoint has a hard limit of 250 commits though so we're still limited unless we switch to a different method of getting them.

Fixes #130 